### PR TITLE
Added endpoints and keep track of active providers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       dockerfile: dockerfile
     stop_signal: SIGINT
     container_name: service-registry
+    env_file:
+      - ./service-registry/.env
     ports:
       - "3000:3000"
 
@@ -20,8 +22,12 @@ services:
     build:
       context: ./service-providers/spotify-music-manager
       dockerfile: dockerfile
+    depends_on:
+      - registry
     stop_signal: SIGINT
     container_name: service-provider-spotify
+    env_file:
+      - ./service-providers/spotify-music-manager/.env
     ports:
       - "3001:3001"
 
@@ -29,6 +35,8 @@ services:
     build:
       context: ./service-providers/apple-music-manager
       dockerfile: dockerfile
+    depends_on:
+      - registry
     stop_signal: SIGINT
     container_name: service-provider-apple
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     stop_signal: SIGINT
     container_name: service-provider-spotify
     env_file:
-      - ./service-providers/spotify-music-manager/.env
+      - ./service-providers/spotify-music-manager/.env.example
     ports:
       - "3001:3001"
 
@@ -39,6 +39,8 @@ services:
       - registry
     stop_signal: SIGINT
     container_name: service-provider-apple
+    env_file:
+      - ./service-providers/apple-music-manager/.env.example
     ports:
       - "3002:3002"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
       dockerfile: dockerfile
     stop_signal: SIGINT
     container_name: service-registry
-    env_file:
-      - ./service-registry/.env
     ports:
       - "3000:3000"
 

--- a/service-providers/apple-music-manager/.env.example
+++ b/service-providers/apple-music-manager/.env.example
@@ -1,0 +1,2 @@
+REGISTRY_URL="http://registry:3000/heartbeat"
+URL="http://apple:3002"

--- a/service-providers/apple-music-manager/dockerfile
+++ b/service-providers/apple-music-manager/dockerfile
@@ -5,10 +5,12 @@ FROM python:3.8-slim
 WORKDIR /app
 
 # Install Flask
-RUN pip3 install Flask
+RUN pip3 install Flask requests flask-cors
 
 # Copy the Python file into the container
-COPY main.py /app/main.py
+COPY *.py /app/
+
+COPY secrets secrets
 
 # Make port 80 available to the world outside this container
 EXPOSE 80

--- a/service-providers/apple-music-manager/main.py
+++ b/service-providers/apple-music-manager/main.py
@@ -1,11 +1,42 @@
-from flask import Flask
+import os
+import sys
+import threading
+import requests
+import time
+import flask
+from flask_cors import CORS
 
-app = Flask(__name__)
+app = flask.Flask(__name__)
+CORS(app)
 
-@app.route('/applemusicmanager')
-def hello_world():
-    return 'This is the apple music manager'
+TIME_BETWEEN_REQUESTS = 30
+
+SEND_HEARTBEAT = True
+
+
+def sendHeartbeat() -> None:
+    global SEND_HEARTBEAT
+    while SEND_HEARTBEAT:
+        data = {
+            "url": os.environ.get('URL'),
+            "type": "register",
+            "name": "Apple Library Manager"
+        }
+        print(requests.post(os.environ.get('REGISTRY_URL'), json=data))
+        time.sleep(TIME_BETWEEN_REQUESTS)
+
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=3002)
+    t1 = threading.Thread(target=sendHeartbeat)
+    t1.start()
+    app.run(host='0.0.0.0', port=3001)
 
+    # unregisters the service from the registry on stop
+    SEND_HEARTBEAT = False
+    endRequest = {
+        "url": os.environ.get('URL'),
+        "type": "unregister",
+        "name": "Apple Library Manager"
+    }
+    requests.post(os.environ.get('REGISTRY_URL'), json=endRequest)
+    t1.join()

--- a/service-providers/spotify-music-manager/.env.example
+++ b/service-providers/spotify-music-manager/.env.example
@@ -1,0 +1,2 @@
+REGISTRY_URL="http://registry:3000/heartbeat"
+URL="http://spotify:3001"

--- a/service-providers/spotify-music-manager/main.py
+++ b/service-providers/spotify-music-manager/main.py
@@ -14,9 +14,12 @@ api = SpotifyAPI.SpotifyAPI()
 
 TIME_BETWEEN_REQUESTS = 30
 
+SEND_HEARTBEAT = True
+
 
 def sendHeartbeat() -> None:
-    while True:
+    global SEND_HEARTBEAT
+    while SEND_HEARTBEAT:
         data = {
             "url": os.environ.get('URL'),
             "type": "register",
@@ -55,4 +58,13 @@ if __name__ == '__main__':
     t1 = threading.Thread(target=sendHeartbeat)
     t1.start()
     app.run(host='0.0.0.0', port=3001)
-    # TODO: Add deregistration heartbeat here
+
+    # unregisters the service from the registry on stop
+    SEND_HEARTBEAT = False
+    endRequest = {
+        "url": os.environ.get('URL'),
+        "type": "unregister",
+        "name": "Spotify Library Manager"
+    }
+    requests.post(os.environ.get('REGISTRY_URL'), json=endRequest)
+    t1.join()

--- a/service-providers/spotify-music-manager/main.py
+++ b/service-providers/spotify-music-manager/main.py
@@ -1,23 +1,45 @@
+import os
+import sys
+import threading
+import requests
+import time
 import flask
 from flask_cors import CORS
 import SpotifyAPI
+
 app = flask.Flask(__name__)
 CORS(app)
-import sys
 
 api = SpotifyAPI.SpotifyAPI()
+
+TIME_BETWEEN_REQUESTS = 30
+
+
+def sendHeartbeat() -> None:
+    while True:
+        data = {
+            "url": os.environ.get('URL'),
+            "type": "register",
+            "name": "Spotify Library Manager"
+        }
+        print(requests.post(os.environ.get('REGISTRY_URL'), json=data))
+        time.sleep(TIME_BETWEEN_REQUESTS)
+
 
 @app.route('/playlists')
 def playlists():
     return api.getPlaylists(flask.request.args.get("username"))
 
+
 @app.route('/playlist')
 def playlist():
     return api.getPlaylist(flask.request.args.get("playlist_id"))
 
+
 @app.route('/client_id')
 def client_id():
     return api.getClientID()
+
 
 @app.route('/get_user_token')
 def get_user_token():
@@ -30,6 +52,7 @@ def get_user_token():
 
 
 if __name__ == '__main__':
+    t1 = threading.Thread(target=sendHeartbeat)
+    t1.start()
     app.run(host='0.0.0.0', port=3001)
-    #TODO: Add deregistration heartbeat here
-
+    # TODO: Add deregistration heartbeat here

--- a/service-registry/dockerfile
+++ b/service-registry/dockerfile
@@ -5,7 +5,7 @@ FROM python:3.8-slim
 WORKDIR /app
 
 # Install Flask
-RUN pip3 install Flask
+RUN pip3 install Flask requests flask-cors
 
 # Copy the Python file into the container
 COPY main.py /app/main.py

--- a/service-registry/main.py
+++ b/service-registry/main.py
@@ -1,11 +1,73 @@
-from flask import Flask
+import copy
+from datetime import datetime
+import re
+import json
+import flask
+from flask_cors import CORS
 
-app = Flask(__name__)
+app = flask.Flask(__name__)
+CORS(app)
 
-@app.route('/serviceregistry')
-def hello_world():
-    return 'This is the service-registry'
+TIME_OUT_TIME = 60
+
+# Format looks like {"provider name": "location of provider", "provider name2": "location of provider2"}
+PROVIDERS = {}
+# Format looks like {"provider name": "time", "provider name2": "time2"}
+PROVIDERS_LAST_HEARTBEAT_TIME = {}
+
+
+@app.route('/heartbeat', methods=['POST'])
+def heartbeat():
+    try:
+        if flask.request.json.get('type') == 'register':
+            if not flask.request.json.get('name') or not flask.request.json.get('url'):
+                raise Exception
+            PROVIDERS[flask.request.json.get("name")] = flask.request.json.get("url")
+            PROVIDERS_LAST_HEARTBEAT_TIME[flask.request.json.get("name")] = datetime.now()
+
+        elif flask.request.json.get('type') == 'unregister':
+            if flask.request.json.get("name") in PROVIDERS:
+                PROVIDERS.pop(flask.request.json.get("name"))
+                PROVIDERS_LAST_HEARTBEAT_TIME.pop(flask.request.json.get("name"))
+
+        else:
+            raise Exception
+    except:
+        return "Error"
+
+    return "Success"
+
+
+@app.route('/search')
+def search():
+    removeTimedOutProviders()
+    if not flask.request.args.get("query"):  # if no query is provided just return all providers
+        return json.dumps({"names": [key for key in PROVIDERS.keys()]})
+
+    query = flask.request.args.get("query")
+    pattern = re.compile(f".*{re.escape(query)}.*")
+    matchedNames = {"names": [key for key in PROVIDERS.keys() if pattern.search(key)]}
+    return json.dumps(matchedNames)
+
+
+# Remove providers that have not sent a heartbeat in the time specified by TIME_OUT_TIME
+def removeTimedOutProviders():
+    currentTime = datetime.now()
+    tempDict = copy.deepcopy(PROVIDERS_LAST_HEARTBEAT_TIME)
+    for key, value in tempDict.items():
+        timeDifference = currentTime - value
+        if timeDifference.total_seconds() > TIME_OUT_TIME:
+            PROVIDERS.pop(key)
+            PROVIDERS_LAST_HEARTBEAT_TIME.pop(key)
+
+
+@app.route('/location')
+def location():
+    if not flask.request.args.get("name") in PROVIDERS:
+        return "Error"
+
+    return json.dumps({"location": PROVIDERS[flask.request.args.get("name")]})
+
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=3000)
-


### PR DESCRIPTION
This adds our needed endpoints for the service registry. There is a heartbeat endpoint to register and deregister providers. There is an endpoint to search for providers given a query. If this query is empty it will return all the providers. When a search begins, it removes all timed out providers then does the search. There is a location endpoint that when given the name of a provider it will return their location.