### PR TITLE
added function to get songs from playlists in common format, and enab…

### DIFF
--- a/service-providers/apple-music-manager/AppleAPI.py
+++ b/service-providers/apple-music-manager/AppleAPI.py
@@ -61,4 +61,10 @@ class AppleAPI:
         print(result.text, flush=True)
         data = result.json()
         return data
+    
+    def getPlaylistTracks(self, mutToken, playlistID):
+        result = requests.get(f"https://api.music.apple.com/v1/me/library/playlists/{playlistID}/tracks", headers=createMutAuth(self._devBearer, mutToken))
+        print(result.text, flush=True)
+        data = result.json()
+        return data
 

--- a/service-providers/apple-music-manager/main.py
+++ b/service-providers/apple-music-manager/main.py
@@ -5,6 +5,7 @@ import requests
 import time
 import flask
 from flask_cors import CORS
+from typing import List
 
 import AppleAPI
 
@@ -16,6 +17,25 @@ api = AppleAPI.AppleAPI()
 TIME_BETWEEN_REQUESTS = 30
 
 SEND_HEARTBEAT = True
+
+def getCommonFormatSongsFromPlaylists(userToken: str, playlistIDs: List[str]):
+    songs = []
+    for playlistID in playlistIDs:
+        playlist = api.getPlaylistTracks(userToken, playlistID)
+        for track in playlist["data"]:
+            newSong = {}
+
+            newSong["songName"] = track["attributes"]["name"]
+            newSong["artist"] = track["attributes"]["artistName"]
+            newSong["genres"] = track["attributes"]["genreNames"]
+            newSong["album"] = track["attributes"]["albumName"]
+            newSong["songLength"] = track["attributes"]["durationInMillis"]
+            newSong["releaseDate"] = track["attributes"]["releaseDate"]
+            newSong["songId"] = track["id"]
+
+            songs.append(newSong)
+
+    return songs
 
 def getRegistryURL() -> str:
     if re.search("localhost", os.environ.get('REGISTRY_URL')):
@@ -46,8 +66,7 @@ def userPlaylists():
 
 @app.route('/export')
 def exportPlaylist():
-    # TODO export common format of chosen playlist
-    return "Apple export endpoint"  # api.getPlaylist(flask.request.args.get("userToken"), flask.request.args.get("playlistId"))
+    return getCommonFormatSongsFromPlaylists(flask.request.args.get("userToken"), [flask.request.args.get("playlistId")])
 
 
 @app.route('/import', methods=['POST'])

--- a/service-providers/apple-music-manager/main.py
+++ b/service-providers/apple-music-manager/main.py
@@ -26,12 +26,12 @@ def getCommonFormatSongsFromPlaylists(userToken: str, playlistIDs: List[str]):
             newSong = {}
 
             newSong["songName"] = track["attributes"]["name"]
-            newSong["artist"] = track["attributes"]["artistName"]
+            newSong["artists"] = [track["attributes"]["artistName"]]
             newSong["genres"] = track["attributes"]["genreNames"]
             newSong["album"] = track["attributes"]["albumName"]
             newSong["songLength"] = track["attributes"]["durationInMillis"]
             newSong["releaseDate"] = track["attributes"]["releaseDate"]
-            newSong["songId"] = track["id"]
+            newSong["appleSongId"] = track["id"]
 
             songs.append(newSong)
 

--- a/service-providers/spotify-music-manager/main.py
+++ b/service-providers/spotify-music-manager/main.py
@@ -37,7 +37,7 @@ def getCommonFormatSongsFromPlaylists(userToken: str, playlistIDs: List[str]):
             newSong["album"] = item["track"]["album"]["name"]
             newSong["songLength"] = item["track"]["duration_ms"]
             newSong["releaseDate"] = item["track"]["album"]["release_date"]
-            newSong["songId"] = item["track"]["id"]
+            newSong["spotifySongId"] = item["track"]["id"]
             
             songs.append(newSong)
 

--- a/service-providers/spotify-music-manager/main.py
+++ b/service-providers/spotify-music-manager/main.py
@@ -7,6 +7,7 @@ import flask
 import re
 from flask_cors import CORS
 import SpotifyAPI
+from typing import List
 
 app = flask.Flask(__name__)
 CORS(app)
@@ -16,6 +17,32 @@ api = SpotifyAPI.SpotifyAPI()
 TIME_BETWEEN_REQUESTS = 30
 
 SEND_HEARTBEAT = True
+
+def getCommonFormatSongsFromPlaylists(userToken: str, playlistIDs: List[str]):
+    songs = []
+    for playlistID in playlistIDs:
+        playlist = api.getPlaylist(userToken, playlistID)
+        for item in playlist["items"]:
+            newSong = {}
+
+            newSong["songName"] = item["track"]["name"]
+            newSongArtists = []
+            newSongGenres = []
+            for artist in item["track"]["artists"]:
+                newSongArtists.append(artist["name"])
+                if ("genres" in artist):
+                    newSongGenres.extend(artist["genres"])
+            newSong["artists"] = newSongArtists
+            newSong["genres"] = newSongGenres
+            newSong["album"] = item["track"]["album"]["name"]
+            newSong["songLength"] = item["track"]["duration_ms"]
+            newSong["releaseDate"] = item["track"]["album"]["release_date"]
+            newSong["songId"] = item["track"]["id"]
+            
+            songs.append(newSong)
+
+    return songs
+
 
 def getRegistryURL() -> str:
     if re.search("localhost", os.environ.get('REGISTRY_URL')):
@@ -47,7 +74,7 @@ def userPlaylists():
 @app.route('/export')
 def exportPlaylist():
     # TODO Export into common format
-    return api.getPlaylist(flask.request.args.get("userToken"), flask.request.args.get("playlistId"))
+    return getCommonFormatSongsFromPlaylists(flask.request.args.get("userToken"), [flask.request.args.get("playlistId")])
 
 
 @app.route('/import', methods=['POST'])


### PR DESCRIPTION
For each of the apple and spotify music library manager, I added a function that takes in 1 or more playlist ids, uses the appropriate API to get the songs from that playlist, and return a list of all those songs in this format:

[
    {
        "songName": "Test2",
        "artist": "Test2",
        "genre": "Test2",
        "album": "Test2",
        "songLength": 999999,
        "releaseDate": "2023-11-23T21:18:07Z",
        "songId": "fsdkljflkasdjflashfkljh"
    },
    {
        "songName": "zTest",
        "artist": "Test",
        "genre": "Test",
        "album": "Test",
        "songLength": 999999,
        "releaseDate": "2023-11-23T21:18:07Z",
        "songId": "fsdkljflkasdjflashfkljh"
    }
]

I used this function in the /export endpoint of both library managers, so when they user downloads a library, they download a list of songs from that library in this format.